### PR TITLE
feat: setting to mark user contributions internal across org

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,7 @@ WEBSITE_ADDRESS="https://github.app.home"
 LOGIN_USER=username
 LOGIN_PASSWORD=strongpassword
 DEFAULT_GITHUB_ORG=Git-Commit-Show
+ONE_CLA_PER_ORG=true
 GITHUB_BOT_USERS=dependabot[bot],devops-github-rudderstack
 GITHUB_ORG_MEMBERS=
 APP_ID="11"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Node.js server for GitHub app to assist external contributors and save maintai
 - [x] On `rudder-transformer` PR merge, post a comment to raise PR in `integrations-config`
 - [ ] On `integrations-config` PR merge, psot a comment to join Slack's product-releases channel to get notified when that integration goes live
 - [ ] On `integrations-config` PR merge, post a comment to raise PR in `rudder-docs`
+- [x] List of open PRs by external contributors
 
 ## Requirements
 

--- a/app.js
+++ b/app.js
@@ -241,6 +241,9 @@ http
       case "GET /contributions/pr":
         routes.getPullRequestDetail(req, res, app);
         break;
+      case "GET /contributions/reset":
+        routes.resetContributionData(req, res, app);
+        break;
       case "POST /api/webhook":
         middleware(req, res);
         break;

--- a/app.js
+++ b/app.js
@@ -1,4 +1,6 @@
 import dotenv from "dotenv";
+// Load environment variables from .env file
+dotenv.config();
 import fs from "fs";
 import http from "http";
 import url from "url";
@@ -22,9 +24,6 @@ try {
 }
 console.log(`Application version: ${APP_VERSION}`);
 console.log(`Website address: ${process.env.WEBSITE_ADDRESS}`);
-
-// Load environment variables from .env file
-dotenv.config();
 
 // Set configured values
 const appId = process.env.APP_ID;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,6 +3,8 @@ import { resolve } from "path";
 import { PROJECT_ROOT_PATH } from "./config.js";
 import url from "node:url";
 
+const ONE_CLA_PER_ORG = process.env.ONE_CLA_PER_ORG?.toLowerCase()?.trim() === "true";
+
 export function parseUrlQueryParams(urlString) {
   if(!urlString) return urlString;
   try{
@@ -79,15 +81,15 @@ export function isExternalContributionMaybe(pullRequest) {
     switch (pullRequest.author_association.toUpperCase()) {
       case "OWNER":
         pullRequest.isExternalContribution = false;
-        storage.cache.set(false, username, "contribution", "external", owner, repo);
+        storage.cache.set(false, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
         return false;
       case "MEMBER":
         pullRequest.isExternalContribution = false;
-        storage.cache.set(false, username, "contribution", "external", owner, repo);
+        storage.cache.set(false, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
         return false;
       case "COLLABORATOR":
         pullRequest.isExternalContribution = false;
-        storage.cache.set(false, username, "contribution", "external", owner, repo);
+        storage.cache.set(false, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
         return false;
       default:
         //Will need more checks to verify author relation with the repo
@@ -96,15 +98,15 @@ export function isExternalContributionMaybe(pullRequest) {
   }
   if (pullRequest?.head?.repo?.full_name !== pullRequest?.base?.repo?.full_name) {
     pullRequest.isExternalContribution = true;
-    storage.cache.set(true, username, "contribution", "external", owner, repo);
+    storage.cache.set(true, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
     return true;
   } else if (pullRequest?.head?.repo?.full_name && pullRequest?.base?.repo?.full_name) {
     pullRequest.isExternalContribution = false;
-    storage.cache.set(false, username, "contribution", "external", owner, repo);
+    storage.cache.set(false, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
     return false;
   }
   // Utilize cache if possible
-  const isConfirmedToBeExternalContributionInPast = storage.cache.get(username, "contribution", "external", owner, repo);
+  const isConfirmedToBeExternalContributionInPast = storage.cache.get(username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
   if (typeof isConfirmedToBeExternalContributionInPast === "boolean") {
     pullRequest.isExternalContribution = isConfirmedToBeExternalContributionInPast;
     return isConfirmedToBeExternalContributionInPast
@@ -126,7 +128,7 @@ async function isExternalContribution(octokit, pullRequest) {
   //TODO: Handle failure in checking permissions for the user
   const deterministicPermissionCheck = await isAllowedToWriteToTheRepo(octokit, username, owner, repo);
   pullRequest.isExternalContribution = deterministicPermissionCheck;
-  storage.cache.set(deterministicPermissionCheck, username, "contribution", "external", owner, repo);
+  storage.cache.set(deterministicPermissionCheck, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
   return deterministicPermissionCheck;
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,7 +3,9 @@ import { resolve } from "path";
 import { PROJECT_ROOT_PATH } from "./config.js";
 import url from "node:url";
 
-const ONE_CLA_PER_ORG = process.env.ONE_CLA_PER_ORG?.toLowerCase()?.trim() === "true";
+function isOneCLAPerOrgEnough() {
+  return process.env.ONE_CLA_PER_ORG?.toLowerCase()?.trim() === "true" ? true : false;
+}
 
 export function parseUrlQueryParams(urlString) {
   if(!urlString) return urlString;
@@ -81,15 +83,15 @@ export function isExternalContributionMaybe(pullRequest) {
     switch (pullRequest.author_association.toUpperCase()) {
       case "OWNER":
         pullRequest.isExternalContribution = false;
-        storage.cache.set(false, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
+        storage.cache.set(false, username, "contribution", "external", owner, isOneCLAPerOrgEnough() ? undefined : repo);
         return false;
       case "MEMBER":
         pullRequest.isExternalContribution = false;
-        storage.cache.set(false, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
+        storage.cache.set(false, username, "contribution", "external", owner, isOneCLAPerOrgEnough() ? undefined : repo);
         return false;
       case "COLLABORATOR":
         pullRequest.isExternalContribution = false;
-        storage.cache.set(false, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
+        storage.cache.set(false, username, "contribution", "external", owner, isOneCLAPerOrgEnough() ? undefined : repo);
         return false;
       default:
         //Will need more checks to verify author relation with the repo
@@ -98,15 +100,15 @@ export function isExternalContributionMaybe(pullRequest) {
   }
   if (pullRequest?.head?.repo?.full_name !== pullRequest?.base?.repo?.full_name) {
     pullRequest.isExternalContribution = true;
-    storage.cache.set(true, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
+    storage.cache.set(true, username, "contribution", "external", owner, isOneCLAPerOrgEnough() ? undefined : repo);
     return true;
   } else if (pullRequest?.head?.repo?.full_name && pullRequest?.base?.repo?.full_name) {
     pullRequest.isExternalContribution = false;
-    storage.cache.set(false, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
+    storage.cache.set(false, username, "contribution", "external", owner, isOneCLAPerOrgEnough() ? undefined : repo);
     return false;
   }
   // Utilize cache if possible
-  const isConfirmedToBeExternalContributionInPast = storage.cache.get(username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
+  const isConfirmedToBeExternalContributionInPast = storage.cache.get(username, "contribution", "external", owner, isOneCLAPerOrgEnough() ? undefined : repo);
   if (typeof isConfirmedToBeExternalContributionInPast === "boolean") {
     pullRequest.isExternalContribution = isConfirmedToBeExternalContributionInPast;
     return isConfirmedToBeExternalContributionInPast
@@ -128,7 +130,7 @@ async function isExternalContribution(octokit, pullRequest) {
   //TODO: Handle failure in checking permissions for the user
   const deterministicPermissionCheck = await isAllowedToWriteToTheRepo(octokit, username, owner, repo);
   pullRequest.isExternalContribution = deterministicPermissionCheck;
-  storage.cache.set(deterministicPermissionCheck, username, "contribution", "external", owner, ONE_CLA_PER_ORG ? undefined : repo);
+  storage.cache.set(deterministicPermissionCheck, username, "contribution", "external", owner, isOneCLAPerOrgEnough() ? undefined : repo);
   return deterministicPermissionCheck;
 }
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -221,6 +221,7 @@ export const routes = {
                       <br/><br/>
                       <div class="pagination">
                           <button class="pagination-button" onclick="goToNextPage()">Next Page...</button>
+                          <a href="/contributions/reset" target="_blank">Reset</button>
                       </div>
                   </body>
                   <script>
@@ -284,6 +285,11 @@ export const routes = {
                       
                   </script>
                   </html>`);
+  },
+  resetContributionData(req, res, app) {
+    storage.cache.clear();
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.write('Cache cleared');
   },
   // ${!Array.isArray(prs) || prs?.length < 1 ? "No contributions found! (Might be an access issue)" : prs?.map(pr => `<li><a href="${pr?.user?.html_url}">${pr?.user?.login}</a> contributed a PR - <a href="${pr?.html_url}" target="_blank">${pr?.title}</a> [${pr?.labels?.map(label => label?.name).join('] [')}]  <small>updated ${timeAgo(pr?.updated_at)}</small></li>`).join('')}
   default(req, res) {

--- a/src/storage.js
+++ b/src/storage.js
@@ -21,6 +21,17 @@ function initCache() {
   }
 }
 
+function clearCache() {
+  CACHE.clear();
+  fs.truncate(cachePath, 0, (err) => {
+    if (err) {
+      console.error('Error truncating cache file:', err);
+    } else {
+      console.log('Cache file content deleted successfully.');
+    }
+  });
+}
+
 async function lazyCacheSnapshot() {
   try {
     const currentTime = new Date().getTime();
@@ -92,6 +103,9 @@ export const storage = {
       let cache = CACHE.set(key, value);
       lazyCacheSnapshot();
       return cache
+    },
+    clear: function () {
+      clearCache();
     }
   }
 };


### PR DESCRIPTION
Add `ONE_CLA_PER_ORG=true` env variable to mark user contributions internal across org. If a user contribution is marked internal for one repo, their all other contributions in other repos will also be marked internal.