### PR TITLE
feat: add api key auth for comment api endpoint

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,7 @@ LOGIN_USER=username
 LOGIN_PASSWORD=strongpassword
 DEFAULT_GITHUB_ORG=Git-Commit-Show
 ONE_CLA_PER_ORG=true
+API_KEY=key_to_protect_endpoints_of_this_app
 API_POST_GITHUB_COMMENT=http://localhost:3000/api/comment #Put your webhook proxy for PR/issue comment here
 DOCS_AGENT_API_URL=docs_agent_api_base_url
 DOCS_AGENT_API_KEY=docs_agent_api_key_here

--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ import {
   getWebsiteAddress,
 } from "./src/helpers.js";
 import DocsAgent from "./src/services/DocsAgent.js";
+import { validateApiKey } from "./src/auth.js";
 
 try {
   const packageJson = await import("./package.json", {
@@ -261,6 +262,11 @@ const server = http
         githubWebhookRequestHandler(req, res);
         break;
       case "POST /api/comment":
+        if (!validateApiKey(req)) {
+          res.writeHead(401);
+          res.write("API key required");
+          return res.end();
+        }
         routes.addCommentToGitHubIssueOrPR(req, res);
         break;
       case "GET /":

--- a/src/auth.js
+++ b/src/auth.js
@@ -15,3 +15,28 @@ export function isPasswordValid(username, password){
     loginAttempts[username] = (loginAttempts[username] || 0) + 1;
     return false
 }
+
+export function validateApiKey(req) {
+    // Check if API_KEY environment variable is set
+    if (!process.env.API_KEY) {
+        console.error("API_KEY environment variable not configured");
+        return false;
+    }
+    
+    // Check for X-API-Key header
+    const apiKeyHeader = req.headers['x-api-key'];
+    if (apiKeyHeader && apiKeyHeader === process.env.API_KEY) {
+        return true;
+    }
+    
+    // Check for Authorization: Bearer <key> header
+    const authHeader = req.headers['authorization'];
+    if (authHeader && authHeader.startsWith('Bearer ')) {
+        const token = authHeader.substring(7); // Remove 'Bearer ' prefix
+        if (token === process.env.API_KEY) {
+            return true;
+        }
+    }
+    
+    return false;
+}

--- a/src/services/DocsAgent.js
+++ b/src/services/DocsAgent.js
@@ -1,5 +1,10 @@
 /**
- * Service for interacting with external APIs to get next actions
+ * Service for interacting with docs agent external APIs to get next actions
+ * 
+ * @example
+ * const docsAgent = new DocsAgent();
+ * const result = await docsAgent.reviewDocs("content", "filepath", { webhookUrl: "webhookUrl", webhookMetadata: { owner: "owner", repo: "repo", issue_number: "issue_number" } });
+ * console.log(result);
  */
 export class DocsAgent {
   constructor() {

--- a/test/e2e/api-key-auth.test.js
+++ b/test/e2e/api-key-auth.test.js
@@ -1,0 +1,96 @@
+/**
+ * Integration tests for API key authentication functionality.
+ */
+import { expect, use } from 'chai';
+import chaiHttp from 'chai-http';
+import { describe, it, before, after } from 'mocha';
+
+const chai = use(chaiHttp);
+const SITE_URL = 'http://localhost:' + (process.env.PORT || 3000);
+
+describe('API Key Authentication', function () {
+    this.timeout(40000);
+    let agent;
+
+    before(function () {
+        agent = chai.request.agent(SITE_URL);
+        // Not setting API key here because it's set in the lifecycle test
+    });
+
+    after(function () {
+        agent.close();
+    });
+
+    describe('POST /api/comment endpoint', function () {
+        const validPayload = {
+            owner: 'test-org',
+            repo: 'test-repo',
+            issue_number: 123,
+            result: 'Test comment'
+        };
+
+        it('should return 401 when no API key is provided', async function () {
+            const res = await agent
+                .post('/api/comment')
+                .send(validPayload);
+            
+            expect(res).to.have.status(401);
+            expect(res.text).to.equal('API key required');
+        });
+
+        it('should return 401 when invalid X-API-Key is provided', async function () {
+            const res = await agent
+                .post('/api/comment')
+                .set('X-API-Key', 'invalid-key')
+                .send(validPayload);
+            
+            expect(res).to.have.status(401);
+            expect(res.text).to.equal('API key required');
+        });
+
+        it('should return 401 when invalid Authorization Bearer is provided', async function () {
+            const res = await agent
+                .post('/api/comment')
+                .set('Authorization', 'Bearer invalid-key')
+                .send(validPayload);
+            
+            expect(res).to.have.status(401);
+            expect(res.text).to.equal('API key required');
+        });
+
+        it('should accept valid X-API-Key header', async function () {
+            const res = await agent
+                .post('/api/comment')
+                .set('X-API-Key', 'test-api-key')
+                .send(validPayload);
+            
+            // Should not return 401 (authentication passed)
+            // Note: This might return 400/500 due to GitHub API calls in test environment
+            // but the important thing is that it's not 401
+            expect(res).to.not.have.status(401);
+        });
+
+        it('should accept valid Authorization Bearer header', async function () {
+            const res = await agent
+                .post('/api/comment')
+                .set('Authorization', 'Bearer test-api-key')
+                .send(validPayload);
+            
+            // Should not return 401 (authentication passed)
+            // Note: This might return 400/500 due to GitHub API calls in test environment
+            // but the important thing is that it's not 401
+            expect(res).to.not.have.status(401);
+        });
+
+        it('should prioritize X-API-Key over Authorization header when both are present', async function () {
+            const res = await agent
+                .post('/api/comment')
+                .set('X-API-Key', 'test-api-key')
+                .set('Authorization', 'Bearer invalid-key')
+                .send(validPayload);
+            
+            // Should not return 401 (X-API-Key takes precedence)
+            expect(res).to.not.have.status(401);
+        });
+    });
+});

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -12,6 +12,11 @@ before(async function () {
 
     if (process.env.RUN_E2E_TESTS === 'true') {
         try {
+
+            if (!process.env.API_KEY) {
+                process.env.API_KEY = 'test-api-key';
+            }
+
             appProcess = spawn('node', ['app.js'], {
                 env: { ...process.env, NODE_ENV: 'test' },
                 stdio: 'pipe'


### PR DESCRIPTION
Make sure that unauthenticated requests are not allowed to comment api endpoint. Protect it with the API key auth.

DEPLOYMENT INSTRUCTIONS: Add a new env var `API_KEY`